### PR TITLE
enqueueJob utility helper

### DIFF
--- a/src/progress.js
+++ b/src/progress.js
@@ -1,4 +1,5 @@
 import Nprogress from 'nprogress'
+import { enqueueJob } from './utils'
 
 export default {
   delay: null,
@@ -105,7 +106,7 @@ export default {
   },
 
   start(event) {
-    Promise.resolve().then(() => {
+    enqueueJob(() => {
       if (event.defaultPrevented) {
         return
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export function enqueueJob(callback) {
+  if (typeof queueMicrotask !== 'undefined' && /native code/.test(queueMicrotask.toString())) {
+    return queueMicrotask(callback)
+  }
+
+  Promise.resolve().then(callback)
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 export function enqueueJob(callback) {
-  if (typeof queueMicrotask !== 'undefined' && /native code/.test(queueMicrotask.toString())) {
+  if (typeof queueMicrotask === 'function') {
     return queueMicrotask(callback)
   }
 


### PR DESCRIPTION
Uses the native queueMicrotask function on the WindowOrWorkerGlobalScope API whenever available.
Falls back to Promises if not.

Closes #2 