### PR TITLE
Bump Inertia peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "nprogress": "^0.2.0"
   },
   "peerDependencies": {
-    "@inertiajs/inertia": "^0.6.0"
+    "@inertiajs/inertia": "^0.6.0 || ^0.7.0"
   }
 }


### PR DESCRIPTION
Because of the breaking change introduced in @inertiajs/inertia v0.7.0, this package now gives a peer dependency warning. This PR solves this.