### PR TITLE
Added option to specify the parent container

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,5 +27,8 @@ InertiaProgress.init({
 
   // Whether the NProgress spinner will be shown.
   showSpinner: false,
+
+  // Specify this to change the parent container. (default: body)
+  parent: 'body',
 })
 ```

--- a/src/progress.js
+++ b/src/progress.js
@@ -111,9 +111,13 @@ function injectCSS(color) {
 }
 
 const Progress = {
-  init({ delay = 250, color = '#29d', includeCSS = true, showSpinner = false } = {}) {
+  init({ delay = 250, color = '#29d', includeCSS = true, showSpinner = false, parent = 'body' } = {}) {
     addEventListeners(delay)
-    NProgress.configure({ showSpinner })
+    NProgress.configure({ 
+      showSpinner,
+      parent
+    })
+
     if (includeCSS) {
       injectCSS(color)
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,6 +30,13 @@ interface ProgressSettings {
 	 * Defaults to false.
 	 */
 	showSpinner?: boolean;
+
+	/**
+	 * Change the parent DOM container.
+	 * 
+	 * Defaults to body
+	 */
+	parent?: string
 }
 
 /**


### PR DESCRIPTION
NProgress provides an option to specify the parent container in the DOM to which the progress bar should be added. 

With the update, the option also becomes available for the Inertiajs progress-wapper.    