### PR TITLE
feat: alternative initialize function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export { default as InertiaProgress } from './progress'
+export { default as InertiaProgress, initializeProgress } from './progress'

--- a/src/progress.js
+++ b/src/progress.js
@@ -121,3 +121,6 @@ const Progress = {
 }
 
 export default Progress
+export function initializeProgress(settings = {}) {
+	Progress.init(settings)
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,3 +44,10 @@ export const InertiaProgress: {
 	 */
 	init(settings?: ProgressSettings): void;
 };
+
+/**
+ * Initializes the progress.
+	 *
+	 * @param settings Optional settings.
+ */
+export function initializeProgress(settings?: ProgressSettings): void


### PR DESCRIPTION
This PR adds an `initializeProgress` function which does the exact same thing as `InertiaProgress#init`, but with a syntax that is more in-line with the usual functional approach of JavaScript. 

Basically, previously, you could do this:
```js
import { createApp, h } from 'vue';
import { createInertiaApp } from '@inertiajs/inertia-vue3';
import { InertiaProgress } from '@inertiajs/progress';

createInertiaApp({
    resolve: (name: string) => import(`./pages/${name}`),
    setup: ({ el, app, props, plugin }) => createApp({ render: () => h(app, props) })
        .use(plugin)
        .mixin({ methods: { route } })
        .mount(el)
});

InertiaProgress.init({ color: '#4B5563' })
```

Now, you can do just like before, or do this: 

```ts
import { createApp, h } from 'vue';
import { createInertiaApp } from '@inertiajs/inertia-vue3';
import { initializeProgress } from '@inertiajs/progress';

createInertiaApp({
    resolve: (name: string) => import(`./pages/${name}`),
    setup: ({ el, app, props, plugin }) => createApp({ render: () => h(app, props) })
        .use(plugin)
        .mixin({ methods: { route } })
        .mount(el)
});

initializeProgress({ color: '#4B5563' })
```

The typings have been updated as well. I'm not 100% sure of the name of `initializeProgress`. Other ideas:
- `registerProgress`
- `makeProgress`