### PR TITLE
add height option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,5 +27,8 @@ InertiaProgress.init({
 
   // Whether the NProgress spinner will be shown.
   showSpinner: false,
+
+  // The height of the progress bar.
+  height : '2px',
 })
 ```

--- a/src/progress.js
+++ b/src/progress.js
@@ -32,7 +32,7 @@ function finish(event) {
   }
 }
 
-function injectCSS(color) {
+function injectCSS(color,height) {
   const element = document.createElement('style')
   element.type = 'text/css'
   element.textContent = `
@@ -49,7 +49,7 @@ function injectCSS(color) {
       left: 0;
 
       width: 100%;
-      height: 2px;
+      height: ${height};
     }
 
     #nprogress .peg {
@@ -111,11 +111,11 @@ function injectCSS(color) {
 }
 
 const Progress = {
-  init({ delay = 250, color = '#29d', includeCSS = true, showSpinner = false } = {}) {
+  init({ delay = 250, color = '#29d', includeCSS = true, showSpinner = false ,height = '2px'} = {}) {
     addEventListeners(delay)
     NProgress.configure({ showSpinner })
     if (includeCSS) {
-      injectCSS(color)
+      injectCSS(color,height)
     }
   },
 }


### PR DESCRIPTION
So that we can control the height of the bar without using css
```
InertiaProgress.init({
  // The delay after which the progress bar will
  // appear during navigation, in milliseconds.
  delay: 250,

  // The color of the progress bar.
  color: '#29d',

  // Whether to include the default NProgress styles.
  includeCSS: true,

  // Whether the NProgress spinner will be shown.
  showSpinner: false,

  // The height of the progress bar.
  height : '2px',
})
```